### PR TITLE
WIP: Store worker events for time period

### DIFF
--- a/src/messages/gateway.rs
+++ b/src/messages/gateway.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::messages::common::{TaskConfiguration, TaskFailInfo, WorkerConfiguration};
-use crate::messages::worker::WorkerOverview;
+use crate::messages::worker::{FromWorkerMessage, ToWorkerMessage, WorkerOverview};
 use crate::{Priority, TaskId, WorkerId};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -62,12 +62,19 @@ pub enum FromGatewayMessage {
     CancelTasks(CancelTasks),
     GetTaskInfo(TaskInfoRequest),
     ServerInfo,
+    GetWorkerEvents(EventRequest),
     GetOverview(OverviewRequest),
     StopWorker(StopWorkerRequest),
 
     // Register names in the request (may be empty) and return ALL names
     // in message GenericResourceNames
     GetGenericResourceNames(GenericResourceNames),
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct EventRequest {
+    //todo: have filters to get events after id/timestamp
+    after_id: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -208,4 +215,11 @@ pub enum ToGatewayMessage {
     LostWorker(LostWorkerMessage),
     WorkerStopped,
     GenericResourceNames(GenericResourceNames),
+    WorkerEventsResponse(WorkerEvents),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct WorkerEvents {
+    pub worker_message_events: Vec<FromWorkerMessage>,
+    pub to_worker_message_events: Vec<ToWorkerMessage>,
 }

--- a/src/messages/worker.rs
+++ b/src/messages/worker.rs
@@ -68,7 +68,7 @@ pub enum ToWorkerMessage {
     Stop,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
 pub struct TaskFinishedMsg {
     pub id: TaskId,
     pub size: u64,

--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -8,7 +8,7 @@ use crate::common::rpc::forward_queue_to_sink_with_map;
 use crate::messages::gateway::{
     CancelTasksResponse, CollectedOverview, ErrorResponse, FromGatewayMessage,
     GenericResourceNames, NewTasksResponse, TaskInfo, TaskState, TaskUpdate, TasksInfoResponse,
-    ToGatewayMessage,
+    ToGatewayMessage, WorkerEvents,
 };
 use crate::messages::worker::{ToWorkerMessage, WorkerOverview};
 use crate::server::comm::{Comm, CommSenderRef};
@@ -232,6 +232,15 @@ pub async fn process_client_message(
             }
             let message = ToGatewayMessage::GenericResourceNames(GenericResourceNames {
                 resource_names: core.generic_resource_names().to_vec(),
+            });
+            assert!(client_sender.send(message).is_ok());
+            None
+        }
+        FromGatewayMessage::GetWorkerEvents(_) => {
+            //todo: get events after a particular id and return
+            let message = ToGatewayMessage::WorkerEventsResponse(WorkerEvents {
+                worker_message_events: vec![],
+                to_worker_message_events: vec![],
             });
             assert!(client_sender.send(message).is_ok());
             None

--- a/src/server/reactor.rs
+++ b/src/server/reactor.rs
@@ -6,15 +6,16 @@ use crate::common::{Map, Set};
 use crate::messages::common::TaskFailInfo;
 use crate::messages::gateway::LostWorkerReason;
 use crate::messages::worker::{
-    NewWorkerMsg, StealResponse, StealResponseMsg, TaskFinishedMsg, TaskIdMsg, TaskIdsMsg,
-    ToWorkerMessage,
+    FromWorkerMessage, NewWorkerMsg, StealResponse, StealResponseMsg, TaskFinishedMsg, TaskIdMsg,
+    TaskIdsMsg, ToWorkerMessage,
 };
 use crate::server::comm::Comm;
-use crate::server::core::Core;
+use crate::server::core::{Core, WorkerEvent};
 use crate::server::task::{DataInfo, TaskRef, TaskRuntimeState};
 use crate::server::task::{FinishInfo, Task, WaitingInfo};
 use crate::server::worker::Worker;
 use crate::{TaskId, WorkerId};
+use std::time::SystemTime;
 
 pub fn on_new_worker(core: &mut Core, comm: &mut impl Comm, worker: Worker) {
     {
@@ -656,6 +657,14 @@ fn remove_task_if_possible(core: &mut Core, comm: &mut impl Comm, task: &mut Tas
         //comm.send_scheduler_message(ToSchedulerMessage::RemoveTask(task.id));
         //comm.send_client_task_removed(task.id);
     }
+}
+
+pub fn insert_worker_message_event(core: &mut Core, event: FromWorkerMessage) {
+    core.insert_worker_message_event(WorkerEvent {
+        message: event,
+        event_id: core.get_event_queue_len(),
+        event_time: SystemTime::now(),
+    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request aims to add worker message logging.

1. Worker messages for the past ```n``` minutes are stored on the server.
2. The client can query the server to get either all events that the server currently has or events after a particular ```event_id``` 

This will allow for the dashboard to have more information available to work with and ability to update it's state through small event messages. 

This PR is very early, but this is to convey my understanding. I'll improve it and remove the WIP when it's ready.
